### PR TITLE
implemented retrieval of cborld qr code against hosted sign-and-verify

### DIFF
--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -29,7 +29,7 @@ export const VerifyDocumentRequest = (source: string) => {
 export const ProvePresentationRequest = (source: any) => {
   return instance.post(`/prove/presentations`, {
     presentation: source, 
-    options: {'verificationMethod': CONFIG.signingKeyId}
+    options: {'verificationMethod': CONFIG.signingKeyId, 'challenge': CONFIG.presentationChallenge}
   });
 };
 

--- a/src/pages/VerifiableCredentialEdit.tsx
+++ b/src/pages/VerifiableCredentialEdit.tsx
@@ -2,8 +2,7 @@ import React, { FC, useCallback, useEffect, useState } from "react";
 import { JSONEditor, LinkedDataPropertyTable, CredentialCard } from "@material-did/common";
 import { ContainerQRCode } from "../utils/styles";
 import { DocProps } from "../components/Props";
-// TODO: this will become relevant when we host sign-and-verify instance
-// import { ProvePresentationRequest } from "../api/index";
+import { ProvePresentationRequest } from "../api/index";
 import styled from "styled-components";
 import COLORS from "../utils/colors";
 import { encodeToQrCodeUrl, encodeToVpUnsigned } from "../utils/codecs";
@@ -44,9 +43,8 @@ export const VerifiableCredentialEdit: FC<DocProps> = ({
 
   const updateQrCodeUrl = async (document: any) => {
     const vpUnsigned = encodeToVpUnsigned(document);
-    // TODO: this will become relevant when we host sign-and-verify instance
-    // const vpSigned = await ProvePresentationRequest(vpUnsigned);
-    const qrCodeUrl = await encodeToQrCodeUrl(vpUnsigned);
+    const vpSigned = (await ProvePresentationRequest(vpUnsigned)).data;
+    const qrCodeUrl = await encodeToQrCodeUrl(vpSigned);
     setQrCodeUrl(qrCodeUrl);
   };
 

--- a/src/samples/didDoc.json
+++ b/src/samples/didDoc.json
@@ -3,13 +3,13 @@
     "https://www.w3.org/ns/did/v1",
     "https://w3id.org/security/suites/ed25519-2020/v1"
   ],
-  "id": "did:web:digitalcredentials.github.io",
+  "id": "did:key:z6MkhVTX9BF3NGYX6cc7jWpbNnR7cAjH8LUffabZP8Qu4ysC",
   "assertionMethod": [
     {
-      "id": "did:web:digitalcredentials.github.io#z6MkrXSQTybtqyMasfSxeRBJxDvDUGqb7mt9fFVXkVn6xTG7",
+      "id": "did:key:z6MkhVTX9BF3NGYX6cc7jWpbNnR7cAjH8LUffabZP8Qu4ysC#z6MkhVTX9BF3NGYX6cc7jWpbNnR7cAjH8LUffabZP8Qu4ysC",
       "type": "Ed25519VerificationKey2020",
-      "controller": "did:web:digitalcredentials.github.io",
-      "publicKeyMultibase": "zD5BMsjMTWRs7mAcFxrDU78NDehZjhtdnyEabvDp63EUj"
+      "controller": "did:key:z6MkhVTX9BF3NGYX6cc7jWpbNnR7cAjH8LUffabZP8Qu4ysC",
+      "publicKeyMultibase": "did:key:z6MkhVTX9BF3NGYX6cc7jWpbNnR7cAjH8LUffabZP8Qu4ysC"
     }
   ]
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,8 +1,9 @@
 import { didDocument } from "./fixtures";
 
 export type Config = {
-  signAndVerifyEndpoint: string,
-  signingKeyId: string,
+  signAndVerifyEndpoint: string;
+  signingKeyId: string;
+  presentationChallenge: string;
 }
 
 
@@ -10,8 +11,9 @@ let CONFIG: null | Config = null;
 
 export function parseConfig(): Config {
   return Object.freeze({
-    signAndVerifyEndpoint: process.env.SIGN_AND_VERIFY_ENDPOINT ? process.env.SIGN_AND_VERIFY_ENDPOINT  : 'https://sign-and-verify.herokuapp.com',
-    signingKeyId: didDocument.assertionMethod[0].id
+    signAndVerifyEndpoint: process.env.SIGN_AND_VERIFY_ENDPOINT ? process.env.SIGN_AND_VERIFY_ENDPOINT  : 'https://kezike-sign-and-verify.herokuapp.com',
+    signingKeyId: didDocument.assertionMethod[0].id,
+    presentationChallenge: 'dcc-pg-123'
   });
 }
 


### PR DESCRIPTION
This PR implements retrieval of CBOR-LD QR codes against a hosted `sign-and-verify` service. In particular, it introduces a call to the `/prove/presentations` endpoint to sign presentations before encoding them into QR codes.